### PR TITLE
SystemUI: Check if a task's group is null prior to TaskGrouping#isFrontM...

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/recents/views/RecentsView.java
+++ b/packages/SystemUI/src/com/android/systemui/recents/views/RecentsView.java
@@ -532,7 +532,7 @@ public class RecentsView extends FrameLayout implements TaskStackView.TaskStackV
         if (tv == null) {
             post(launchRunnable);
         } else {
-            if (!task.group.isFrontMostTask(task)) {
+            if (task.group != null && !task.group.isFrontMostTask(task)) {
                 // For affiliated tasks that are behind other tasks, we must animate the front cards
                 // out of view before starting the task transition
                 stackView.startLaunchTaskAnimation(tv, launchRunnable, lockToTask);


### PR DESCRIPTION
...ostTask.

    java.lang.NullPointerException: Attempt to invoke virtual method 'boolean
    com.android.systemui.recents.model.TaskGrouping.isFrontMostTask(com.android.systemui.recents.model.Task)' on a null object reference
      at com.android.systemui.recents.views.RecentsView.onTaskViewClicked(RecentsView.java:535)
      at com.android.systemui.recents.views.TaskStackView.onTaskViewClicked(TaskStackView.java:1125)
      at com.android.systemui.recents.views.TaskView.onClick(TaskView.java:881)
      at android.view.View.performClick(View.java:4756)
      at android.view.View$PerformClick.run(View.java:19749)
      at android.os.Handler.handleCallback(Handler.java:739)
      at android.os.Handler.dispatchMessage(Handler.java:95)

Change-Id: I04afec21a7c4e7ba5b3e51ae76a2065e98e6cfa2